### PR TITLE
create site directory in post-rollout task

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -25,6 +25,11 @@ tasks:
         service: nginx
         container: php
     - run:
+        name: Create languages/site directory
+        command: mkdir -p -v -m775 /app/web/application/languages/site
+        service: nginx
+        container: php
+    - run:
         name: Run Concrete CMS c5:update
         command: /app/vendor/bin/concrete c5:update --env=live
         service: cli

--- a/lagoon/cli.dockerfile
+++ b/lagoon/cli.dockerfile
@@ -13,7 +13,6 @@ RUN composer install --no-dev --prefer-dist
 COPY . /app
 RUN mkdir -p -v -m775 /app/web/application/cache
 RUN mkdir -p -v -m775 /app/web/application/files
-RUN mkdir -p -v -m775 /app/web/application/languages
 
 # Define where the Concrete CMS webroot is located
 ENV WEBROOT=web


### PR DESCRIPTION
サイトインターフェースを翻訳出来ないエラーまた出ましたので、site directory 作成を post-rollout タスクで設定しました。
開発環境に確認済みです。