### PR TITLE
change PHP default settings

### DIFF
--- a/.env
+++ b/.env
@@ -4,5 +4,6 @@ COMPOSE_PROJECT_NAME=concretecms-base
 # Declare the Concrete environment
 CONCRETE5_ENV="live"
 
-# Change PHP Upload File Size Limits
-PHP_UPLOAD_MAX_FILESIZE=30M
+# Change PHP Default Settings
+PHP_UPLOAD_MAX_FILESIZE=32M
+PHP_POST_MAX_SIZE=32M


### PR DESCRIPTION
Change the default PHP settings for our Lagoon setup to:

upload_max_filesize = 32M
post_max_size = 32M