### PR TITLE
align local env DB with prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ This template includes the following services:
 * Concrete CMS 9.3
 * PHP 8.3 (FPM)
 * Nginx
-* MariaDB 10.11
+* MySQL 8.0
+
+According to Lagoon's specifications, when using lagoon.type: mariadb, 
+the system automatically selects a managed MySQL service. 
+The jp1.amazee.io cluster provides AWS Aurora MySQL 8.0.
 
 ## Initial Setup
 
@@ -51,6 +55,13 @@ After starting the pygmy, you need to start the docker containers using the foll
 docker compose up -d
 ```
 
+If you previously built the volume with mariadb, you need to down the volume before starting the containers.
+
+```bash
+docker compose down -v
+docker compose up -d
+```
+
 If you want to check the status of the local environment, you can use the following command:
 
 ```bash
@@ -79,8 +90,8 @@ docker compose up -d --force-recreate
 To rebuild images, you can use the following command:
 
 ```bash
-docker-compose down
-docker-compose up -d --build
+docker compose down
+docker compose up -d --build
 ```
 
 ### Install Concrete

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       << : *default-environment # loads the defined environment variables from the top
 
   mariadb:
-    image: uselagoon/mariadb-10.11:latest
+    image: uselagoon/mysql-8.0:latest
     labels:
       lagoon.type: mariadb
       lando.type: mariadb


### PR DESCRIPTION
change mariadb-10.11 to mysql-8.0.
Tested in dev.

local 環境に実行するときは、以前 mariadb で voulme build してので volume down するのが必要です。
(switching from MariaDB on the same volume)

```
docker compose down -v
docker compose up -d
```

<img width="1072" height="642" alt="image" src="https://github.com/user-attachments/assets/8e31cbce-88e5-4225-a83e-aa212e588597" />
